### PR TITLE
Tweak: (`vertix-prisma`) - Add missing indexes to bot and guild models

### DIFF
--- a/packages/vertix-prisma/prisma/bot.schema.prisma
+++ b/packages/vertix-prisma/prisma/bot.schema.prisma
@@ -55,6 +55,9 @@ model Category {
   // ---
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
+
+  @@index([categoryId])
+  @@index([guildId])
 }
 
 model Guild {
@@ -110,6 +113,10 @@ model Channel {
   // ---
   createdAt        DateTime                 @default(now())
   updatedAt        DateTime                 @updatedAt
+
+  @@index([guildId])
+  @@index([categoryId])
+  @@index([userOwnerId])
 }
 
 model ChannelData {


### PR DESCRIPTION
### **User description**
Indexes were added to the bot and guild models to improve query performance. This should enhance the efficiency when filtering based on categoryId, guildId, and userOwnerId attributes. Additionally, commented code in the ChannelData model was cleaned up.


___

### **PR Type**
enhancement


___

### **Description**
- Added indexes to the `Category` model on `categoryId` and `guildId` to enhance query performance.
- Added indexes to the `Channel` model on `guildId`, `categoryId`, and `userOwnerId` to improve filtering efficiency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bot.schema.prisma</strong><dd><code>Add missing indexes to improve query performance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/vertix-prisma/prisma/bot.schema.prisma

<li>Added indexes to <code>Category</code> model for <code>categoryId</code> and <code>guildId</code>.<br> <li> Added indexes to <code>Channel</code> model for <code>guildId</code>, <code>categoryId</code>, and <br><code>userOwnerId</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/VertixGG/vertix.gg/pull/110/files#diff-e5748fe2090537af9b6382f1e7c152a28573fedc9e3265a2edcf433699447659">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

