### PR TITLE
fix: Preserve channel configuration when changing privacy state

### DIFF
--- a/packages/vertix-bot/src/services/dynamic-channel-service.ts
+++ b/packages/vertix-bot/src/services/dynamic-channel-service.ts
@@ -672,8 +672,15 @@ export class DynamicChannelService extends ServiceWithDependenciesBase<{
             `Guild id: '${ guild.id }' - Creating dynamic channel '${ dynamicChannelName }' for user '${ displayName }' ownerId: '${ userOwnerId }' version: '${ masterChannelDB.version }'`
         );
 
+        const defaultPropertiesMerged = { ... defaultProperties };
+
+        // Extend from auto saved data.
+        Object.assign( defaultPropertiesMerged.permissionOverwrites, permissionOverwrites );
+
         // Create a channel for the user.
         const dynamic = await this.services.channelService.create( {
+            ...defaultProperties,
+            // ---
             guild,
             // ---
             name: dynamicChannelName,
@@ -687,10 +694,6 @@ export class DynamicChannelService extends ServiceWithDependenciesBase<{
             internalType: PrismaBot.E_INTERNAL_CHANNEL_TYPES.DYNAMIC_CHANNEL,
             // ---
             version: masterChannelDB.version,
-            // ---
-            ...defaultProperties,
-            // --- Overwrite by saved data ---
-            permissionOverwrites,
         } );
 
         if ( !dynamic ) {

--- a/packages/vertix-bot/src/ui/v2/channel-buttons-template/channel-buttons-template-select-menu.ts
+++ b/packages/vertix-bot/src/ui/v2/channel-buttons-template/channel-buttons-template-select-menu.ts
@@ -29,11 +29,17 @@ export class ChannelButtonsTemplateSelectMenu extends UIElementStringSelectMenu 
 
     protected async getSelectOptions() {
         const values = allItems.map( async( item ) => {
+            const itemId = item.getId();
+            // Get the template buttons and ensure we're comparing the same types
+            const templateButtons = ( this.uiArgs?.dynamicChannelButtonsTemplate || [] ).map(
+                ( id: string | number ) => typeof id === "string" ? parseInt( id ) : id
+            );
+
             return {
                 label: await item.getLabelForMenu(),
-                value: item.getId().toString(),
+                value: itemId.toString(),
                 emoji: ( await item.getEmoji() ) as any,
-                default: ( this.uiArgs?.dynamicChannelButtonsTemplate || [] ).includes( item.getId() )
+                default: templateButtons.includes( itemId )
             };
         } );
 

--- a/packages/vertix-bot/src/ui/v3/dynamic-channel/primary-message/dynamic-channel-primary-message-elements-group.ts
+++ b/packages/vertix-bot/src/ui/v3/dynamic-channel/primary-message/dynamic-channel-primary-message-elements-group.ts
@@ -44,7 +44,9 @@ export class DynamicChannelPrimaryMessageElementsGroup extends UIElementsGroupBa
 
     private static mapButtons( allItems: DynamicChannelButtonBase[] ) {
         allItems.forEach( ( item ) => {
-            this.allButtonsById[ item.getId() ] = item;
+            const itemId = item.getId();
+
+            this.allButtonsById[ itemId ] = item;
             this.allButtonsByName[ item.getName() ] = item;
         } );
     }
@@ -107,6 +109,7 @@ export class DynamicChannelPrimaryMessageElementsGroup extends UIElementsGroupBa
     }
 
     public static getById( id: string ) {
+        // Use the getItemFromMap method directly with the id
         return this.getItemFromMap( this.allButtonsById, id );
     }
 
@@ -151,11 +154,37 @@ export class DynamicChannelPrimaryMessageElementsGroup extends UIElementsGroupBa
     }
 
     public static sortIds( ids: string[] ) {
-        return ids.sort(
-            ( aId: string, bId: string ) =>
-                DynamicChannelPrimaryMessageElementsGroup.getById( aId )!.$$.getSortId() -
-                DynamicChannelPrimaryMessageElementsGroup.getById( bId )!.$$.getSortId()
-        );
+        if ( !ids ) {
+            return [];
+        }
+
+        if ( !Array.isArray( ids ) ) {
+            return ids;
+        }
+
+        if ( ids.length === 0 ) {
+            return ids;
+        }
+
+        try {
+            const result = ids.sort(
+                ( aId: string, bId: string ) => {
+                    const aItem = DynamicChannelPrimaryMessageElementsGroup.getById( aId );
+                    const bItem = DynamicChannelPrimaryMessageElementsGroup.getById( bId );
+
+                    if ( !aItem || !bItem ) {
+                        return 0;
+                    }
+
+                    return aItem.$$.getSortId() - bItem.$$.getSortId();
+                }
+            );
+
+            return result;
+        } catch {
+            // Return unsorted array if there's an error
+            return ids;
+        }
     }
 }
 

--- a/packages/vertix-bot/src/ui/v3/setup-new/setup-new-wizard-adapter.ts
+++ b/packages/vertix-bot/src/ui/v3/setup-new/setup-new-wizard-adapter.ts
@@ -259,15 +259,27 @@ export class SetupNewWizardAdapter extends UIWizardAdapterBase<BaseGuildTextChan
     }
 
     private async onButtonsSelected( interaction: UIDefaultStringSelectMenuChannelTextInteraction ) {
+        // Get existing args
+        const existingArgs = this.getArgsManager().getArgs( this, interaction );
+
+        // Keep button IDs as strings (don't parse to integers)
+        const buttonValues = interaction.values;
+
+        // Preserve existing args while updating the button template
         this.getArgsManager().setArgs( this, interaction, {
-            dynamicChannelButtonsTemplate: interaction.values.map( ( i ) => parseInt( i ) )
+            ...existingArgs,
+            dynamicChannelButtonsTemplate: buttonValues
         } );
 
         await this.editReplyWithStep( interaction, "VertixBot/UI-General/SetupStep2Component" );
     }
 
     private async onConfigExtrasSelected( interaction: UIDefaultStringSelectMenuChannelTextInteraction ) {
-        const argsToSet: UIArgs = {},
+        // Get existing args to preserve them
+        const existingArgs = this.getArgsManager().getArgs( this, interaction );
+
+        // Start with existing args to preserve button template and other settings
+        const argsToSet: UIArgs = { ...existingArgs },
             values = interaction.values;
 
         values.forEach( ( value ) => {
@@ -298,6 +310,7 @@ export class SetupNewWizardAdapter extends UIWizardAdapterBase<BaseGuildTextChan
         }
 
         this.getArgsManager().setArgs( this, interaction, {
+            ...args,
             dynamicChannelVerifiedRoles: roles.sort()
         } );
 

--- a/packages/vertix-gui/src/bases/ui-args-manager.ts
+++ b/packages/vertix-gui/src/bases/ui-args-manager.ts
@@ -114,7 +114,8 @@ export class UIArgsManager extends InitializeBase {
             this.debugger.dumpDown( this.setInitialArgs, this.data[ self.getName() ][ id ] );
 
             if ( !internalArgs.silent ) {
-                throw new Error( `${ this.prefixName }: Args with name: '${ self.getName() }' id: '${ id }' already exists` );
+                this.logger.error( this.setInitialArgs, `${ this.prefixName }: Args with name: '${ self.getName() }' id: '${ id }' already exists` );
+                return;
             }
 
             this.logger.error( this.setInitialArgs, `${ this.prefixName }: Args with id: '${ id }' already exists` );


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Preserve channel configuration when changing privacy state.

- Add fallback logic for missing master channel data.

- Enhance logging and maintain consistency in channel settings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dynamic-channel-service.ts</strong><dd><code>Preserve channel settings and improve privacy state handling</code></dd></summary>
<hr>

packages/vertix-bot/src/services/dynamic-channel-service.ts

<li>Added logic to fetch master channel for configuration preservation.<br> <li> Updated privacy state handling to maintain all channel settings.<br> <li> Introduced fallback mechanism for missing master channel data.<br> <li> Enhanced logging and minor code consistency improvements.


</details>


  </td>
  <td><a href="https://github.com/VertixGG/vertix.gg/pull/113/files#diff-8b63c8cbb077ecadb9579bc918181cdd9ba96aad0865d45e2b5d020eaba0718a">+30/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>