### PR TITLE
fix(vertix-bot): new created dynamic channel didnt preserve auto saved permissions

### DIFF
--- a/packages/vertix-bot/src/services/dynamic-channel-service.ts
+++ b/packages/vertix-bot/src/services/dynamic-channel-service.ts
@@ -672,8 +672,15 @@ export class DynamicChannelService extends ServiceWithDependenciesBase<{
             `Guild id: '${ guild.id }' - Creating dynamic channel '${ dynamicChannelName }' for user '${ displayName }' ownerId: '${ userOwnerId }' version: '${ masterChannelDB.version }'`
         );
 
+        const defaultPropertiesMerged = { ... defaultProperties };
+
+        // Extend from auto saved data.
+        Object.assign( defaultPropertiesMerged.permissionOverwrites, permissionOverwrites );
+
         // Create a channel for the user.
         const dynamic = await this.services.channelService.create( {
+            ...defaultProperties,
+            // ---
             guild,
             // ---
             name: dynamicChannelName,
@@ -687,10 +694,6 @@ export class DynamicChannelService extends ServiceWithDependenciesBase<{
             internalType: PrismaBot.E_INTERNAL_CHANNEL_TYPES.DYNAMIC_CHANNEL,
             // ---
             version: masterChannelDB.version,
-            // ---
-            ...defaultProperties,
-            // --- Overwrite by saved data ---
-            permissionOverwrites,
         } );
 
         if ( !dynamic ) {


### PR DESCRIPTION
### **User description**
merge default properties with permissions

Refactored the dynamic channel creation logic to merge default properties with permission overwrites before channel creation. This ensures that saved data properly extends default configurations, improving clarity and maintainability.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed dynamic channel creation to preserve auto-saved permissions.

- Merged default properties with permission overwrites for clarity.

- Refactored logic to improve maintainability and extendability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dynamic-channel-service.ts</strong><dd><code>Refactored dynamic channel creation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/vertix-bot/src/services/dynamic-channel-service.ts

<li>Added merging of default properties with permission overwrites.<br> <li> Removed redundant overwriting of saved data in channel creation.<br> <li> Improved clarity and maintainability of dynamic channel creation <br>logic.


</details>


  </td>
  <td><a href="https://github.com/VertixGG/vertix.gg/pull/114/files#diff-8b63c8cbb077ecadb9579bc918181cdd9ba96aad0865d45e2b5d020eaba0718a">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>