### PR TITLE
fix(vertix-bot): fix verified roles not applied to new dynamic-channel

### DIFF
--- a/packages/vertix-base/src/managers/master-channel-data-manager.ts
+++ b/packages/vertix-base/src/managers/master-channel-data-manager.ts
@@ -90,12 +90,12 @@ export class MasterChannelDataManager extends InitializeBase {
             ?.dynamicChannelAutoSave;
     }
 
-    public async getChannelVerifiedRoles( masterChannelDB: ChannelExtended, guildId: string, cache = true ) {
+    public async getChannelVerifiedRoles( masterChannelDB: ChannelExtended, guildId: string, cache = true ): Promise<string[]> {
         return (
             await this.getModel( masterChannelDB ).getSettings( masterChannelDB.id, cache, ( result ) =>
-                result?.length ? result : [ guildId ]
+                result?.dynamicChannelVerifiedRoles.length ? result : { dynamicChannelVerifiedRoles: undefined }
             )
-        )?.dynamicChannelVerifiedRoles;
+        )?.dynamicChannelVerifiedRoles ?? [ guildId ];
     }
 
     public async getChannelLogsChannelId( masterChannelDB: ChannelExtended ) {

--- a/packages/vertix-bot/src/services/dynamic-channel-service.ts
+++ b/packages/vertix-bot/src/services/dynamic-channel-service.ts
@@ -552,7 +552,7 @@ export class DynamicChannelService extends ServiceWithDependenciesBase<{
         } );
 
         // Check if autosave is enabled.
-        const autoSave = await MasterChannelDataManager.$.getChannelAutosave( masterChannelDB, true );
+        const autoSave = await MasterChannelDataManager.$.getChannelAutosave( masterChannelDB, false );
 
         let savedData: MasterChannelUserDataInterface | null = null,
             dynamicChannelName = "",
@@ -582,16 +582,11 @@ export class DynamicChannelService extends ServiceWithDependenciesBase<{
             dynamicChannelUserLimit = savedData.dynamicChannelUserLimit;
 
             const verifiedRoles =
-                    ( await MasterChannelDataManager.$.getChannelVerifiedRoles(
+                    await MasterChannelDataManager.$.getChannelVerifiedRoles(
                         masterChannelDB,
                         masterChannel.guildId
-                    ) ) || [],
+                     ),
                 verifiedFlagsSet: bigint[] = [];
-
-            // TODO: Find the root cause of this issue, above function expect to return at least guild id in this case.
-            if ( !verifiedRoles.length ) {
-                verifiedRoles.push( guild.id );
-            }
 
             const {
                 dynamicChannelState,


### PR DESCRIPTION
### **User description**
Updated `getChannelVerifiedRoles` to properly handle cases where no verified roles are returned by avoiding unnecessary fallback logic. Adjusted the autosave default parameter in `getChannelAutosave` to prevent incorrect assumptions.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed `getChannelVerifiedRoles` to handle empty results correctly.

- Adjusted `getChannelAutosave` default parameter to prevent incorrect assumptions.

- Removed redundant fallback logic for verified roles in `DynamicChannelService`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>master-channel-data-manager.ts</strong><dd><code>Fix verified roles handling in `getChannelVerifiedRoles`</code>&nbsp; </dd></summary>
<hr>

packages/vertix-base/src/managers/master-channel-data-manager.ts

<li>Updated <code>getChannelVerifiedRoles</code> to return an empty array instead of <br>undefined.<br> <li> Added explicit return type <code>Promise<string[]></code> to <code>getChannelVerifiedRoles</code>.<br> <li> Adjusted fallback logic for verified roles to avoid unnecessary <br>defaults.


</details>


  </td>
  <td><a href="https://github.com/VertixGG/vertix.gg/pull/115/files#diff-e017db0af477e7b17ac8f08212dbb999497a01939188ace8c3ec86537b5b0ac8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dynamic-channel-service.ts</strong><dd><code>Adjust autosave and verified roles logic in dynamic channels</code></dd></summary>
<hr>

packages/vertix-bot/src/services/dynamic-channel-service.ts

<li>Changed <code>getChannelAutosave</code> default parameter from <code>true</code> to <code>false</code>.<br> <li> Removed redundant fallback logic for verified roles.<br> <li> Simplified logic for retrieving verified roles in dynamic channels.


</details>


  </td>
  <td><a href="https://github.com/VertixGG/vertix.gg/pull/115/files#diff-8b63c8cbb077ecadb9579bc918181cdd9ba96aad0865d45e2b5d020eaba0718a">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>